### PR TITLE
fix: remove obsolete custom licenses

### DIFF
--- a/Block/Catalog/Product/Usage.php
+++ b/Block/Catalog/Product/Usage.php
@@ -128,6 +128,7 @@ class Usage extends AbstractProduct
                 ->create();
             $searchCriteria = $this->searchCriteriaBuilder
                 ->addFilter('category_id', $customLicenseId, 'neq')
+                ->addFilter('is_active', 1)
                 ->addSortOrder($sortOrder)
                 ->create();
             $items = $this->usageRepository->getList($searchCriteria)->getItems();
@@ -146,6 +147,9 @@ class Usage extends AbstractProduct
                         'entity_id',
                         $customerUsage,
                         'in'
+                    )->addFilter(
+                        'is_active',
+                        1
                     )->create();
                     $customerUsageItems = $this->usageRepository->getList($searchCriteria)->getItems();
                     /** @var \DevStone\UsageCalculator\Model\Usage $customerUsageItem */

--- a/Controller/Adminhtml/Usage/Delete.php
+++ b/Controller/Adminhtml/Usage/Delete.php
@@ -65,6 +65,7 @@ class Delete extends Action
         try {
             $objectInstance = $this->objectFactory->create()->load($id);
             if ($objectInstance->getId()) {
+                $this->deleteUsageCustomer((int)$id);
                 $objectInstance->delete();
                 $this->messageManager->addSuccessMessage(__('You deleted the record.'));
             } else {
@@ -73,19 +74,20 @@ class Delete extends Action
         } catch (\Exception $exception) {
             $this->messageManager->addErrorMessage($exception->getMessage());
         }
-        $this->deleteUsageCustomer();
         return $resultRedirect->setPath('*/*');
     }
 
     /**
+     * Delete custom-license customer assignments for a usage.
      *
+     * @param int|null $usageId Usage entity ID; defaults to the request value.
      */
-    public function deleteUsageCustomer()
+    public function deleteUsageCustomer(?int $usageId = null)
     {
         $collection = $this->usageCollectionFactory->create();
 
-        $id = $this->getRequest()->getParam('entity_id', null);
-        $collection->addFieldToFilter('usage_id', ['eq' => $id]);
+        $usageId ??= (int)$this->getRequest()->getParam('entity_id');
+        $collection->addFieldToFilter('usage_id', ['eq' => $usageId]);
 
         foreach ($collection as $usage) {
             $usage->delete();

--- a/Controller/Adminhtml/Usage/MassDelete.php
+++ b/Controller/Adminhtml/Usage/MassDelete.php
@@ -62,8 +62,9 @@ class MassDelete extends Action
     {
         $collection = $this->filter->getCollection($this->objectCollection);
         $collectionSize = $collection->getSize();
+        $usageIds = $collection->getAllIds();
+        $this->deleteUsageCustomer($usageIds);
         $collection->walk('delete');
-        $this->deleteUsageCustomer();
         $this->messageManager->addSuccessMessage(__('A total of %1 record(s) have been deleted.', $collectionSize));
 
         /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
@@ -73,12 +74,17 @@ class MassDelete extends Action
 
     /**
      * Delete all the Custom License Usage
+     *
+     * @param int[] $usageIds Usage entity IDs selected for deletion.
      */
-    public function deleteUsageCustomer()
+    public function deleteUsageCustomer(array $usageIds)
     {
+        if ($usageIds === []) {
+            return;
+        }
+
         $collection = $this->usageCollectionFactory->create();
-        $selectedUsage = $this->getRequest()->getParam('selected');
-        $collection->addFieldToFilter('usage_id', ['in' => $selectedUsage]);
+        $collection->addFieldToFilter('usage_id', ['in' => $usageIds]);
         foreach ($collection as $usage) {
             $usage->delete();
         }

--- a/Observer/SaveCustomer.php
+++ b/Observer/SaveCustomer.php
@@ -48,7 +48,7 @@ class SaveCustomer implements ObserverInterface
             ->addFilter('customer_id', 0, 'neq');
         if (isset($customers)) {
 
-            $customersArray = json_decode((string) $customers);
+            $customersArray = json_decode((string) $customers, true, 512, JSON_THROW_ON_ERROR);
             foreach ($customersArray as $customerId) {
                 $usageCustomer = $this->usageCustomerFactory->create();
 
@@ -59,7 +59,9 @@ class SaveCustomer implements ObserverInterface
                 $usageCustomer = $this->usageCustomerRepository->save($usageCustomer);
                 $savedIds[] = $usageCustomer->getId();
             }
-            $searchCriteria->addFilter('entity_id', $savedIds, 'nin');
+            if ($savedIds !== []) {
+                $searchCriteria->addFilter('entity_id', $savedIds, 'nin');
+            }
         }
         $this->usageCustomerRepository->deleteList($searchCriteria->create());
 
@@ -82,7 +84,9 @@ class SaveCustomer implements ObserverInterface
                 $usageCustomer = $this->usageCustomerRepository->save($usageCustomer);
                 $savedIds[] = $usageCustomer->getId();
             }
-            $searchCriteria->addFilter('entity_id', $savedIds, 'nin');
+            if ($savedIds !== []) {
+                $searchCriteria->addFilter('entity_id', $savedIds, 'nin');
+            }
         }
         $this->usageCustomerRepository->deleteList($searchCriteria->create());
     }


### PR DESCRIPTION
## Summary

- Delete custom-license customer assignments before deleting one or more licenses.
- Remove deselected customer and pending-email assignments instead of applying an empty `NOT IN` filter.
- Exclude inactive usages from standard and customer-specific license dropdowns.

## Verification

- `php -l` on all changed PHP files
- `vendor/bin/phpcs --standard=Magento2` on changed files: 0 errors; existing legacy warnings remain
- Local Magento dev fixtures: customer unassignment, custom-license deletion, and inactive-license dropdown exclusion passed
- `curl -kI https://goodsalt2.test/` returned `HTTP/2 200`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Usage lookups now show only active records, improving result accuracy.
  - Deleting a usage record also removes its related customer assignments.
  - Bulk deletion now consistently removes associated customer assignments for all selected records.
  - Improved handling of invalid customer data to prevent incomplete or misleading saved-customer filters.
  - Empty selections no longer trigger unnecessary cleanup operations during bulk actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->